### PR TITLE
add a test that identify() gets called on page load

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,7 @@ lint: node_modules
 # Test locally in PhantomJS.
 test-phantomjs: node_modules build.js
 	@$(DUOT) phantomjs $(TESTS_DIR) args: \
-		--ignore-ssl-errors=true --path node_modules/.bin/phantomjs
+		--ignore-ssl-errors=true --ssl-protocol=tlsv1 --path node_modules/.bin/phantomjs
 .PHONY: test-phantomjs
 
 # Test locally in the browser.

--- a/lib/index.js
+++ b/lib/index.js
@@ -103,8 +103,9 @@ function convertDate(date) {
  */
 
 Drift.prototype.page = function(page) {
-  if (!this.identified && page.userId()) {
-    window.drift.identify(page.userId());
+  var userId = this.analytics.user().id();
+  if (!this.identified && userId) {
+    window.drift.identify(userId);
     this.identified = true;
   }
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -106,5 +106,26 @@ describe('Drift', function() {
         analytics.called(window.drift.track, 'event', { date: Math.floor(date / 1000) });
       });
     });
+
+    describe('#page', function() {
+      beforeEach(function() {
+        analytics.stub(window.drift, 'page');
+        analytics.stub(window.drift, 'identify');
+      });
+
+      it('should send an page view event and should not send another identify event', function() {
+        analytics.identify('id');
+        analytics.calledOnce(window.drift.identify);
+
+        analytics.page('page');
+        analytics.called(window.drift.page, 'page');
+        analytics.calledOnce(window.drift.identify);
+      });
+
+      it('should send an page view event and an identify event', function() {
+        analytics.page('page');
+        analytics.calledOnce(window.drift.identify, 'id');
+      });
+    });
   });
 });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -113,17 +113,34 @@ describe('Drift', function() {
         analytics.stub(window.drift, 'identify');
       });
 
-      it('should send an page view event and should not send another identify event', function() {
+      it('should send a page view event but not an identify event', function() {
+        // track a page view
+        analytics.page('page');
+
+        analytics.called(window.drift.page, 'page');
+        analytics.didNotCall(window.drift.identify);
+      });
+
+      it('should send an page view event but only one identify event', function() {
+        // set the user id by calling identify
         analytics.identify('id');
         analytics.calledOnce(window.drift.identify);
 
+        // track a page view
         analytics.page('page');
+
         analytics.called(window.drift.page, 'page');
         analytics.calledOnce(window.drift.identify);
       });
 
-      it('should send an page view event and an identify event', function() {
+      it('should send a page view event and an identify event', function() {
+        // set the user id explicitly
+        analytics.user().id('id');
+
+        // track a page view
         analytics.page('page');
+
+        analytics.called(window.drift.page, 'page');
         analytics.calledOnce(window.drift.identify, 'id');
       });
     });


### PR DESCRIPTION
adds some additional tests for `#page`.
- `drift.identify` is called on `#page` if it hasn't been called yet
- `drift.identify` is not called again on `#page` if it has already been called
